### PR TITLE
Issue 35 confidence score handling

### DIFF
--- a/bin/tagpack-tool
+++ b/bin/tagpack-tool
@@ -18,6 +18,7 @@ from tagpack.tagpack import TagPack, TagPackFileError, collect_tagpack_files, ge
 from tagpack.tagpack_schema import TagPackSchema, ValidationError
 from tagpack.tagstore import TagStore
 from tagpack.taxonomy import Taxonomy
+from tagpack.confidence import Confidence
 
 CONFIG_FILE = "config.yaml"
 
@@ -27,6 +28,9 @@ DEFAULT_CONFIG = {
     'taxonomies': {
         'entity': f'{TAXONOMY_URL}/DW-VA-Taxonomy/assets/data/entities.csv',
         'abuse': f'{TAXONOMY_URL}/DW-VA-Taxonomy/assets/data/abuses.csv'
+    },
+    'confidence': {
+        'scores': 'tagpack/db/confidence.csv'
     }
 }
 
@@ -51,6 +55,15 @@ def _remote_load_taxonomy(config, key):
     taxonomy = Taxonomy(key, uri)
     taxonomy.load_from_remote()
     return taxonomy
+
+
+def _local_load_confidence_scores(config):
+    if 'confidence' not in config:
+        return None
+    path = config['confidence']['scores']
+    confidence = Confidence(path)
+    confidence.load_from_local()
+    return confidence
 
 
 def list_taxonomies(args=None):
@@ -122,6 +135,71 @@ def insert_taxonomy(args):
         except Exception as e:
             print_fail(e)
             print_line("Aborted insert", 'fail')
+
+
+def list_confidence_scores(args):
+    config = _load_config(args.config)
+
+    print_line("Show configured confidence scores")
+    print_line(f"Configuration: {args.config}", 'info')
+    count = 0
+    if 'confidence' not in config:
+        print_line("No confidence scores configured", 'fail')
+    else:
+        for key, value in config['confidence'].items():
+            print_line(value)
+            count += 1
+        print_line(f"{count} configured confidence scores", 'success')
+
+
+def show_confidence_scores(args):
+    config = _load_config(args.config)
+
+    if 'confidence' not in config:
+        print_line("No confidence scores configured", 'fail')
+        return
+
+    print_line("Showing confidence scores")
+    print("Local path: ", config['confidence']['scores'], "\n")
+    confidence = _local_load_confidence_scores(config)
+    if args.verbose:
+        headers = ['id', 'label', 'description', 'level']
+        table = [[c.id, c.label, c.description, c.level]
+                 for c in confidence.scores]
+    else:
+        headers = ['Level', 'Label']
+        table = [[c.level, c.label] for c in confidence.scores]
+
+    print(tabulate(table, headers=headers))
+    print_line(f"{len(confidence.scores)} confidence scores", 'success')
+
+
+def ingest_confidence_scores(args):
+    config = _load_config(args.config)
+
+    if 'confidence' not in config:
+        print_line("No confidence scores configured", 'fail')
+        return
+
+    t0 = time.time()
+    print_line("Confidence scores ingest starts")
+
+    tagstore = TagStore(args.url, args.schema)
+
+    try:
+        confidence = _local_load_confidence_scores(config)
+        tagstore.insert_confidence_scores(confidence, args.force)
+
+        print(f"{confidence.path}:", end=' ')
+        print_success("INSERTED")
+
+        duration = round(time.time() - t0, 2)
+        print_line(
+            f"Inserted {len(confidence.scores)} scores in {duration}s",
+            'success')
+    except Exception as e:
+        print_fail(e)
+        print_line("Aborted ingestion", 'fail')
 
 
 def _load_config(cfile):
@@ -318,6 +396,35 @@ def main():
     parser_t_s.add_argument('-v', '--verbose', action='store_true',
                             help="verbose concepts")
     parser_t_s.set_defaults(func=show_taxonomy_concepts)
+
+
+    # parser for confidence command
+    parser_s = subparsers.add_parser("confidence",
+                                     help="show confidence scores")
+    parser_s.set_defaults(func=list_confidence_scores)
+
+    parser_s_subparsers = parser_s.add_subparsers(title='Confidence commands')
+
+    # parser for confidence ingest command
+    parser_s_i = parser_s_subparsers.add_parser(
+        'ingest', help='ingest confidence scores into GraphSense')
+    parser_s_i.add_argument("--force", action='store_true',
+                            help='Force re-insertion of confidence scores.')
+    parser_s_i.add_argument('--schema',
+                            default=_DEFAULT_SCHEMA, metavar='DB_SCHEMA',
+                            help="PostgreSQL schema for confidence tables")
+    parser_s_i.add_argument('-u', '--url',
+                    help="postgresql://user:password@db_host:port/database")
+    parser_s_i.set_defaults(func=ingest_confidence_scores)
+
+    # parser for confidence show command
+    parser_s_s = parser_s_subparsers.add_parser(
+        'show', help='show confidence scores')
+    parser_s_s.add_argument('-v', '--verbose', action='store_true',
+                            help="verbose concepts")
+    parser_s_s.set_defaults(func=show_confidence_scores)
+
+
 
     # parser for config command
     parser_c = subparsers.add_parser("config",

--- a/tagpack/confidence.py
+++ b/tagpack/confidence.py
@@ -1,0 +1,53 @@
+"""Confidence - A proxy for a local confidence definition"""
+
+import csv, json
+from io import StringIO
+
+
+class Score(object):
+    """Score Definition.
+    This class serves as a proxy for a score that is locally defined.
+    """
+
+    def __init__(self, id, label, description, level):
+        self.id = id
+        self.label = label
+        self.description = description
+        self.level = level
+
+    def to_json(self):
+        return json.dumps(
+            {'id': self.id, 'label': self.label,
+                'description': self.description, 'level': self.level})
+
+    def __str__(self):
+        return f"[{self.id}|{self.label}|{self.description}|{self.level}]"
+
+
+class Confidence(object):
+    """TagPack Confidence Proxy.
+    This class serves as a proxy for locally defined confidence scores.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.scores = []
+
+    def load_from_local(self):
+        with open(self.path, 'r') as f:
+            csv_reader = csv.DictReader(f, delimiter=',')
+            for row in csv_reader:
+                score = Score(row['id'], row['label'], row['description'],
+                            row['level'])
+                self.scores.append(score)
+
+    @property
+    def score_ids(self):
+        return [score.id for score in self.scores]
+
+    def to_json(self):
+        return json.dumps({'path': self.path,
+            'scores': [json.loads(score.to_json()) for score in self.scores]})
+
+    def __str__(self):
+        return f"[{self.path}|n_scores:{len(self.score_ids)}]"

--- a/tagpack/tagstore.py
+++ b/tagpack/tagstore.py
@@ -27,6 +27,21 @@ class TagStore(object):
 
         self.conn.commit()
 
+    def insert_confidence_scores(self, confidence, force):
+        statement = "INSERT INTO confidence (id, label, description, level)"
+        statement += " VALUES (%s, %s, %s, %s)"
+
+        # TODO What to do with foreign key restrictions?
+#        if force:
+#            print(f"evicting and re-inserting all confidence scores")
+#            self.cursor.execute("DELETE FROM confidence")
+
+        for c in confidence.scores:
+            values = (c.id, c.label, c.description, c.level)
+            self.cursor.execute(statement, values)
+
+        self.conn.commit()
+
     def tp_exists(self, prefix, rel_path):
         if not self.existing_packs:
             self.existing_packs = self.get_ingested_tagpacks()


### PR DESCRIPTION
Code for ingesting the confidence scores from the local file in tagpack/db/confidence.csv to the database; --force parameter is not supported yet, we need to figure out what to do with foreign-keys dependencies (e.g. table tag).