### PR TITLE
Issue 39 normalize eth addresses

### DIFF
--- a/tagpack/tagstore.py
+++ b/tagpack/tagstore.py
@@ -143,7 +143,10 @@ def _get_tag(tag, tagpack_id):
 
 
 def _get_address(tag):
-    return tag.all_fields.get('currency'), tag.all_fields.get('address')
+    curr = tag.all_fields.get('currency')
+    addr = tag.all_fields.get('address')
+    addr = addr.lower() if 'ETH' == curr.upper() else addr
+    return curr, addr
 
 
 def _get_header(tagpack, tid):


### PR DESCRIPTION
ETH addresses are normalized to lower-case just before inserting them to the db. Addresses from other currencies remain mixed-case.