### PR TITLE
Issue 51: Produce a warning if tagpack addresses contain whitespace

### DIFF
--- a/tagpack/tagpack.py
+++ b/tagpack/tagpack.py
@@ -281,9 +281,11 @@ class TagPack(object):
             currency = tag.all_fields.get('currency', '').lower()
             cupper = currency.upper()
             address = tag.all_fields.get('address')
-            if currency in self.verifiable_currencies:
+            if len(address) != len(address.strip()):
+                print_warn(f"\tAddress contains whitespace: {repr(address)}")
+            elif currency in self.verifiable_currencies:
                 v = coinaddrvalidator.validate(currency, address)
-                if not v:
+                if not v.valid:
                     print_warn(f"\tNot a valid {cupper} address: {address}")
             else:
                 unsupported[cupper].add(address)

--- a/tests/test_tagpack.py
+++ b/tests/test_tagpack.py
@@ -198,6 +198,25 @@ def test_valid_addresses(tagpack, capsys):
     assert captured.out == ''
 
 
+def test_addresses_whitespace(tagpack, capsys):
+    tagpack.contents['tags'] = [
+        {'label': 'binance1',
+         'address': '1NDyJtNTjmwk5xPNhjgAMu4HDHigtobu1s '},
+        {'label': 'binance2',
+         'address': '1NDyJtNTjmwk5xPNhjgAMu4HDHigtobu1s\t'},
+        {'label': 'binance3',
+         'address': '\n1NDyJtNTjmwk5xPNhjgAMu4HDHigtobu1s'},
+    ]
+    tagpack.verify_addresses()
+    captured = capsys.readouterr()
+    msg1 = "Address contains whitespace: '1NDyJtNTjmwk5xPNhjgAMu4HDHigtobu1s '"
+    msg2 = "Address contains whitespace: '1NDyJtNTjmwk5xPNhjgAMu4HDHigtobu1s\\t'"
+    msg3 = "Address contains whitespace: '\\n1NDyJtNTjmwk5xPNhjgAMu4HDHigtobu1s'"
+    assert msg1 in captured.out
+    assert msg2 in captured.out
+    assert msg3 in captured.out
+
+
 def test_invalid_addresses(tagpack, capsys):
     tagpack.verify_addresses()
     captured = capsys.readouterr()


### PR DESCRIPTION
A quick check to see if tagpacks contain addresses with whitespace (this can cause the validation step to not detect a valid address)