### PR TITLE
Issue 49 quality measures

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository provides a command line tool for managing [GraphSense TagPacks](
 1. [validating TagPacks against the TagPack schema](#validation)
 2. [handling taxonomies and concepts](#taxonomies)
 3. [ingesting TagPacks and related data into a TagStore](#tagstore)
+4. [calculating the quality of the tags in the TagStore](#quality)
 
 Please note that the last feature requires (installation of) a [Postgresql](https://www.postgresql.org/) database.
 
@@ -159,6 +160,18 @@ For setups which expect many parallel connections to the tagstore it can be a go
     POSTGRES_PASSWORD_TAGSTORE=<PASSWORD>
 
 for example in the your local .env file. Currently, the pg-bounce setup only allows connections with this specific user configured in POSTGRES_USER_TAGSTORE.
+
+## Calculate the quality of the tags in the TagStore <a name="quality"></a>
+
+To assess on the quality of address tags we define a quality measure. For an address, it is calculated as the weighted similarity distance between all pairs of distinct tags assigned to the same address. For instance, an address with a unique tag has a quality equal to 1, while an address with several similar tags has a quality close to 0.
+
+To calculate the quality measure for all the tags in the database, run:
+
+    tagpack-tool quality calculate -u postgresql://$USER:$PASSWORD@$DBHOST:$DBPORT/tagstore
+
+To show the quality measures of all the tags in the database, or those of a specific crypto-currency, run:
+
+    tagpack-tool quality show -u postgresql://$USER:$PASSWORD@$DBHOST:$DBPORT/tagstore [--currency [BCH|BTC|ETH|LTC|ZEC]]
 
 ## Working in development / testing mode
 

--- a/bin/tagpack-tool
+++ b/bin/tagpack-tool
@@ -202,6 +202,51 @@ def ingest_confidence_scores(args):
         print_line("Aborted ingestion", 'fail')
 
 
+def show_quality_measures(args):
+    print_line("Show quality measures")
+    tagstore = TagStore(args.url, args.schema)
+
+    try:
+        qm = tagstore.get_quality_measures(args.currency)
+        c = args.currency if args.currency else 'Global '
+        print(f"{c} quality measures:")
+        if qm:
+            print(f"\tCOUNT:  {qm['count']}")
+            print(f"\tAVG:    {qm['avg']}")
+            print(f"\tSTDDEV: {qm['stddev']}")
+        else:
+            print("\tNone")
+
+    except Exception as e:
+        print_fail(e)
+        print_line("Operation failed", 'fail')
+
+
+def calc_quality_measures(args):
+    t0 = time.time()
+    print_line("Calculate quality measures starts")
+
+    tagstore = TagStore(args.url, args.schema)
+
+    try:
+        qm = tagstore.calculate_quality_measures()
+        print(f"Global quality measures:")
+        if qm is not None:
+            print(f"\tCOUNT:  {qm['count']}")
+            print(f"\tAVG:    {qm['avg']}")
+            print(f"\tSTDDEV: {qm['stddev']}")
+        else:
+            print("\tNone")
+
+        duration = round(time.time() - t0, 2)
+        print_line(
+            f"Done in {duration}s",
+            'success')
+    except Exception as e:
+        print_fail(e)
+        print_line("Operation failed", 'fail')
+
+
 def _load_config(cfile):
     if not os.path.isfile(cfile):
         print_line(
@@ -414,29 +459,59 @@ def main():
 
     # parser for confidence command
     parser_s = subparsers.add_parser("confidence",
-                                     help="show confidence scores")
+            help="show confidence scores")
     parser_s.set_defaults(func=list_confidence_scores)
 
     parser_s_subparsers = parser_s.add_subparsers(title='Confidence commands')
 
     # parser for confidence ingest command
-    parser_s_i = parser_s_subparsers.add_parser(
-        'ingest', help='ingest confidence scores into GraphSense')
+    parser_s_i = parser_s_subparsers.add_parser('ingest',
+            help='ingest confidence scores into GraphSense')
     parser_s_i.add_argument("--force", action='store_true',
-                            help='Force re-insertion of confidence scores.')
+            help='Force re-insertion of confidence scores.')
     parser_s_i.add_argument('--schema',
-                            default=_DEFAULT_SCHEMA, metavar='DB_SCHEMA',
-                            help="PostgreSQL schema for confidence tables")
+            default=_DEFAULT_SCHEMA, metavar='DB_SCHEMA',
+            help="PostgreSQL schema for confidence tables")
     parser_s_i.add_argument('-u', '--url',
-                    help="postgresql://user:password@db_host:port/database")
+            help="postgresql://user:password@db_host:port/database")
     parser_s_i.set_defaults(func=ingest_confidence_scores)
 
     # parser for confidence show command
-    parser_s_s = parser_s_subparsers.add_parser(
-        'show', help='show confidence scores')
+    parser_s_s = parser_s_subparsers.add_parser('show',
+            help='show confidence scores')
     parser_s_s.add_argument('-v', '--verbose', action='store_true',
-                            help="verbose concepts")
+            help="verbose concepts")
     parser_s_s.set_defaults(func=show_confidence_scores)
+
+    # parser for quality measures
+    parser_q = subparsers.add_parser("quality",
+            help="calculate tags quality measures")
+    parser_q.set_defaults(func=show_quality_measures)
+
+    parser_q_subparsers = parser_q.add_subparsers(title='Quality commands')
+
+    # parser for quality measures calculation
+    parser_q_i = parser_q_subparsers.add_parser('calculate',
+            help='calculate quality measures for all tags in the DB')
+    parser_q_i.add_argument('--schema',
+            default=_DEFAULT_SCHEMA, metavar='DB_SCHEMA',
+            help="PostgreSQL schema for quality measures tables")
+    parser_q_i.add_argument('-u', '--url',
+            help="postgresql://user:password@db_host:port/database")
+    parser_q_i.set_defaults(func=calc_quality_measures)
+
+    # parser for quality measures show
+    parser_q_s = parser_q_subparsers.add_parser('show',
+            help='show average quality measures')
+    parser_q_s.add_argument('--currency',
+            default='', choices=['BCH', 'BTC', 'ETH', 'LTC', 'ZEC'],
+            help="Show the avg quality measure for a specific crypto-currency")
+    parser_q_s.add_argument('--schema',
+            default=_DEFAULT_SCHEMA, metavar='DB_SCHEMA',
+            help="PostgreSQL schema for quality measures tables")
+    parser_q_s.add_argument('-u', '--url',
+            help="postgresql://user:password@db_host:port/database")
+    parser_q_s.set_defaults(func=show_quality_measures)
 
     # parser for config command
     parser_c = subparsers.add_parser("config",

--- a/tagpack/db/tagstore_schema.sql
+++ b/tagpack/db/tagstore_schema.sql
@@ -246,3 +246,128 @@ CREATE VIEW duplicate_tags AS
     ORDER BY
         count DESC;
 
+-- Quality measures
+
+DROP TABLE IF EXISTS address_quality;
+CREATE TABLE IF NOT EXISTS address_quality(
+	id SERIAL PRIMARY KEY,
+	currency currency,
+	address VARCHAR,
+	n_tags INTEGER,
+	n_dif_tags INTEGER,
+	total_pairs INTEGER,
+	q1 INTEGER,
+	q2 INTEGER,
+	q3 INTEGER,
+	q4 INTEGER,
+	quality NUMERIC
+);
+
+-- Procedure to calculate the quality measures, usage: CALL calculate_quality();
+
+CREATE PROCEDURE calculate_quality()
+LANGUAGE PLPGSQL
+AS $$
+DECLARE
+	i RECORD;
+	e RECORD;
+	s RECORD;
+	sim NUMERIC;
+BEGIN
+	DROP TABLE IF EXISTS quality_pairs;
+	CREATE TEMP TABLE IF NOT EXISTS quality_pairs(
+		id SERIAL PRIMARY KEY,
+		currency currency,
+		address VARCHAR,
+		label1 VARCHAR,
+		label2 VARCHAR,
+		sim NUMERIC
+	);
+
+	DROP TABLE IF EXISTS quality_labels;
+	CREATE TEMP TABLE IF NOT EXISTS quality_labels(
+		id SERIAL PRIMARY KEY,
+		currency currency,
+		address VARCHAR,
+		label VARCHAR,
+		label_id INTEGER
+	);
+	FOR i in SELECT t.currency, t.address, COUNT(DISTINCT(t.label)) n_labels FROM tag t GROUP BY currency, address HAVING COUNT(DISTINCT(t.label)) > 1 LOOP
+		FOR e in SELECT * FROM tag WHERE currency=i.currency AND address=i.address LOOP
+			-- RAISE NOTICE '%:%', e.address, e.label;
+			FOR s in SELECT u.label label, similarity(u.label, e.label) simi FROM quality_labels u WHERE u.address = e.address LOOP
+				-- RAISE NOTICE '% <-> % = %', e.label, s.label, s.simi;
+				sim = s.simi;
+				INSERT INTO quality_pairs (currency, address, label1, label2, sim)
+				VALUES (e.currency, e.address, e.label, s.label, sim);
+			END LOOP;
+		        INSERT INTO quality_labels (currency, address, label, label_id)
+		        VALUES (e.currency, e.address, e.label, e.id);
+		END LOOP;
+	END LOOP;
+END $$;
+
+-- Save quality measures into address_quality table
+
+CREATE PROCEDURE insert_address_quality()
+LANGUAGE PLPGSQL
+AS $$
+BEGIN
+INSERT INTO address_quality
+	(currency, address, n_tags, n_dif_tags, total_pairs, q1, q2, q3, q4, quality)
+SELECT
+	tags.currency, tags.address, tags.n_tags, tags.n_dif_tags,
+	pairs.total total_pairs, sim.q1, sim.q2, sim.q3, sim.q4,
+	1-((sim.q1*0.25+sim.q2*0.5+sim.q3*0.75+sim.q4*1.0)/pairs.total::float) quality
+FROM (
+	SELECT
+		t.currency, t.address, COUNT(t.label) n_tags, COUNT(DISTINCT(t.label)) n_dif_tags
+	FROM tag t
+	GROUP BY t.currency, t.address
+	HAVING COUNT(DISTINCT(t.label)) > 1
+) tags
+LEFT OUTER JOIN (
+	SELECT
+		q.currency, q.address, COUNT(q.sim) n_sim
+	FROM quality_pairs q
+	WHERE q.sim <= 0.25
+	GROUP BY q.currency, q.address
+) quality_q1
+ON tags.currency = quality_q1.currency AND tags.address = quality_q1.address
+LEFT OUTER JOIN (
+	SELECT
+		q.currency, q.address, COUNT(q.sim) n_sim
+	FROM quality_pairs q
+	WHERE q.sim > 0.25 AND q.sim <= 0.5
+	GROUP BY q.currency, q.address
+) quality_q2
+ON tags.currency = quality_q2.currency AND tags.address = quality_q2.address
+LEFT OUTER JOIN (
+	SELECT
+		q.currency, q.address, COUNT(q.sim) n_sim
+	FROM quality_pairs q
+	WHERE q.sim > 0.50 AND q.sim <= 0.75
+	GROUP BY q.currency, q.address
+) quality_q3
+ON tags.currency = quality_q3.currency AND tags.address = quality_q3.address
+LEFT OUTER JOIN (
+	SELECT
+		q.currency, q.address, COUNT(q.sim) n_sim
+	FROM quality_pairs q
+	WHERE q.sim > 0.75
+	GROUP BY q.currency, q.address
+) quality_q4
+ON tags.currency = quality_q4.currency AND tags.address = quality_q4.address
+CROSS JOIN LATERAL (
+	SELECT
+		coalesce(quality_q1.n_sim, 0),
+		coalesce(quality_q2.n_sim, 0),
+		coalesce(quality_q3.n_sim, 0),
+		coalesce(quality_q4.n_sim, 0)
+) as sim(q1, q2, q3, q4)
+CROSS JOIN LATERAL (
+	SELECT
+		(sim.q1+sim.q2+sim.q3+sim.q4)
+) as pairs(total);
+END $$;
+

--- a/tagpack/tagstore.py
+++ b/tagpack/tagstore.py
@@ -148,6 +148,33 @@ class TagStore(object):
         self.cursor.execute("SELECT id from tagpack")
         return [i[0] for i in self.cursor.fetchall()]
 
+    def get_quality_measures(self, currency='') -> float:
+        '''
+        This function returns a dict with the quality measures (count, avg, and
+        stddev) for a specific currency, or for all if currency is not
+        specified.
+        '''
+        currency = currency.upper()
+        if currency not in ['', 'BCH', 'BTC', 'ETH', 'LTC', 'ZEC']:
+            raise ValidationError("Currency not supported: {currency}")
+
+        query = 'SELECT COUNT(quality), AVG(quality), STDDEV(quality)'
+        query += ' FROM address_quality'
+        if currency:
+            query += ' WHERE currency=%s'
+            self.cursor.execute(query, (currency,))
+        else:
+            self.cursor.execute(query)
+
+        keys = ['count', 'avg', 'stddev']
+        return {keys[i]:v for row in self.cursor.fetchall() \
+                    for i,v in enumerate(row)}
+
+    def calculate_quality_measures(self) -> float:
+        self.cursor.execute("CALL calculate_quality()")
+        self.cursor.execute("CALL insert_address_quality()")
+        return self.get_quality_measures()
+
 
 def _get_tag(tag, tagpack_id):
     label = tag.all_fields.get('label').lower().strip()

--- a/tagpack/tagstore.py
+++ b/tagpack/tagstore.py
@@ -173,6 +173,7 @@ class TagStore(object):
     def calculate_quality_measures(self) -> float:
         self.cursor.execute("CALL calculate_quality()")
         self.cursor.execute("CALL insert_address_quality()")
+        self.conn.commit()
         return self.get_quality_measures()
 
 


### PR DESCRIPTION
Added two procedures to the `tagpack/db/tagstore_schema.sql` file. The former calculates, for each address in the database having more than one different tag, the pair-wise distance similarity between its tags. The latter calculates the quality measure of each address using the pair-wise distances, and stores the result in a table called address_quality.

Also added the command `quality` to `tagpack-tool` to calculate and show the quality measures.