### PR TITLE
Normalise BCH CashAddr formt to legacy when inserting to tagstore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ GitPython~=3.1
 giturlparse~=0.10
 coinaddrvalidator~=1.1.3
 colorama~=0.4.6
+cashaddress~=1.0.4

--- a/tagpack/tagstore.py
+++ b/tagpack/tagstore.py
@@ -7,6 +7,7 @@ from psycopg2.extensions import register_adapter, AsIs
 from psycopg2.extras import execute_batch
 
 from tagpack import ValidationError
+from cashaddress.convert import to_legacy_address
 
 register_adapter(np.int64, AsIs)
 
@@ -255,10 +256,22 @@ def _get_tag(tag, tagpack_id):
     )
 
 
+def _perform_address_modifications(address, curr):
+    if "BCH" == curr.upper() and address.startswith('bitcoincash'):
+        address = to_legacy_address(address)
+
+    elif "ETH" == curr.upper():
+        address = address.lower()
+
+    return address
+
+
 def _get_currency_and_address(tag):
     curr = tag.all_fields.get("currency")
     addr = tag.all_fields.get("address")
-    addr = addr.lower() if "ETH" == curr.upper() else addr
+
+    addr = _perform_address_modifications(addr, curr)
+
     return curr, addr
 
 

--- a/tests/test_tagstore.py
+++ b/tests/test_tagstore.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from tagpack.tagstore import _perform_address_modifications
+
+
+def test_bch_conversion():
+    cashaddr = 'bitcoincash:prseh0a4aejjcewhc665wjqhppgwrz2lw5txgn666a'
+
+    # as per https://bch.btc.com/tools/address-converter
+    expected = '3NFvYKuZrxTDJxgqqJSfouNHjT1dAG1Fta'
+    result = _perform_address_modifications(cashaddr, 'BCH')
+
+    assert expected == result
+
+
+def test_eth_conversion():
+    checksumaddr = '0xC61b9BB3A7a0767E3179713f3A5c7a9aeDCE193C'
+
+    expected = '0xc61b9bb3a7a0767e3179713f3a5c7a9aedce193c'
+    result = _perform_address_modifications(checksumaddr, 'ETH')
+
+    assert expected == result
+
+


### PR DESCRIPTION
Addresses #56, specifically changes CashAddr to legacy format only when ingesting into the tagstore.