### PR TITLE
Speedup insert

### DIFF
--- a/src/tagpack/cli.py
+++ b/src/tagpack/cli.py
@@ -484,13 +484,11 @@ def insert_tagpack(args):
         taxonomies,
         public,
         force,
-        single_thread_mode=n_processes == 1,
         validate_tagpack=not args.no_validation,
     )
 
     if n_processes != 1:
-        pool = Pool(processes=n_processes, initializer=worker.initializer)
-
+        pool = Pool(processes=n_processes)
         results = list(pool.imap_unordered(worker, packs, chunksize=10))
     else:
         # process data in the main process, makes debugging easier

--- a/src/tagpack/tagstore.py
+++ b/src/tagpack/tagstore.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import textwrap
+import time
 from datetime import datetime
 from functools import wraps
 from typing import List
@@ -7,10 +8,12 @@ from typing import List
 import numpy as np
 from cashaddress.convert import to_legacy_address
 from psycopg2 import connect
+from psycopg2.errors import DeadlockDetected
 from psycopg2.extensions import AsIs, register_adapter
 from psycopg2.extras import execute_batch, execute_values
 
 from tagpack import ValidationError
+from tagpack.cmd_utils import print_warn
 from tagpack.utils import get_github_repo_url
 
 register_adapter(np.int64, AsIs)
@@ -37,6 +40,25 @@ def auto_commit(function):
         return output
 
     return wrapper
+
+
+def retry_on_deadlock(times=1):
+    def innerfun(function):
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            attempt = 0
+            while attempt < times:
+                try:
+                    return function(*args, **kwargs)
+                except DeadlockDetected:
+                    time.sleep(1)
+                    print_warn(f"Deadlock Detected retrying, n={times-attempt} times")
+                    attempt += 1
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return innerfun
 
 
 class TagStore(object):
@@ -114,6 +136,7 @@ class TagStore(object):
     def create_id(self, prefix, rel_path):
         return ":".join([prefix, rel_path]) if prefix else rel_path
 
+    @retry_on_deadlock(times=3)
     @auto_commit
     def insert_tagpack(
         self, tagpack, is_public, force_insert, prefix, rel_path, batch=1000

--- a/src/tagpack/tagstore.py
+++ b/src/tagpack/tagstore.py
@@ -13,10 +13,74 @@ from psycopg2.extensions import AsIs, register_adapter
 from psycopg2.extras import execute_batch, execute_values
 
 from tagpack import ValidationError
-from tagpack.cmd_utils import print_warn
+from tagpack.cmd_utils import print_fail, print_info, print_success, print_warn
+from tagpack.tagpack import TagPack
 from tagpack.utils import get_github_repo_url
 
 register_adapter(np.int64, AsIs)
+
+
+class InsertTagpackWorker:
+    def __init__(
+        self,
+        url,
+        db_schema,
+        tp_schema,
+        taxonomies,
+        public,
+        force,
+        single_thread_mode=False,
+        validate_tagpack=False,
+    ):
+        self.url = url
+        self.db_schema = db_schema
+        self.tp_schema = tp_schema
+        self.taxonomies = taxonomies
+        self.public = public
+        self.force = force
+        # if in single thread mode
+        # instead of creating an new instance every time
+        self.tagstore = (
+            TagStore(self.url, self.db_schema) if single_thread_mode else None
+        )
+        self.validate_tagpack = validate_tagpack
+
+    def initializer(self):
+        # per worker initializer
+        # see https://docs.python.org/3/library/multiprocessing.html
+        # this should initialize a new db connection per process
+        # https://stackoverflow.com/questions/64860575/initialize-each-instance-for-each-worker-of-multprocessing # noqa
+        # import os
+        # print("{} with PID {} initialized".format(self, os.getpid()))
+        global PER_PROCESS_TAGSTORE_CONNECTION
+        PER_PROCESS_TAGSTORE_CONNECTION = TagStore(self.url, self.db_schema)
+
+    def get_tagstore_connection(self):
+        global PER_PROCESS_TAGSTORE_CONNECTION
+        return self.tagstore if self.tagstore else PER_PROCESS_TAGSTORE_CONNECTION
+
+    def __call__(self, data):
+        i, tp = data
+        tagstore = self.get_tagstore_connection()
+        if tagstore is None:
+            raise Exception("Connection to tagstore needs to be initialized properly!")
+        tagpack_file, headerfile_dir, uri, relpath, default_prefix = tp
+        tagpack = TagPack.load_from_file(
+            uri, tagpack_file, self.tp_schema, self.taxonomies, headerfile_dir
+        )
+
+        try:
+            print_info(f"{i} {tagpack_file}: INSERTING {len(tagpack.tags)} Tags")
+            if self.validate_tagpack:
+                tagpack.validate()
+            tagstore.insert_tagpack(
+                tagpack, self.public, self.force, default_prefix, relpath
+            )
+            print_success(f"{i} {tagpack_file}: PROCESSED {len(tagpack.tags)} Tags")
+            return 1, len(tagpack.tags)
+        except Exception as e:
+            print_fail(f"{i} {tagpack_file}: FAILED", e)
+            return 0, 0
 
 
 def auto_commit(function):


### PR DESCRIPTION
The PR looks great to me. I have added the following:

- parameters to control the number of workers (--n-workers; defaults to 1 so parallel is opt-in,  0, and negative numbers can be used to as offset to cpu_count, positive values just specify the nr of workers)
- added opt-out validation to the tagpack insertion; not really related to the PR but I was startled that this was not already done
- added retry handling for deadlock situations.
- added a single thread mode that runs the insert in the main thread as before (makes pdb debugging way easier)
- added code to share the tagstore connection (one per worker process). Otherwise, every tagpack established a new connection to the database.
